### PR TITLE
Fix tagid and Wftag in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## dev
+
+* `wftag` now parsed as a float instead of an integer in KB Core and CSS3 schemas
+* `Wftag` primary keys are `tagname`, `tagid`, and `wfid` instead of just `tagid`
+
 ## 0.3.1
 
 * Pisces no longer requires compiling and installing C extension modules.
@@ -7,7 +12,6 @@
   with a NumPy-only version.
 * Remove `libecompression` C library, and move it to a separate "e1" package on PyPI.
   It will be installed as an optional dependency by installing with `pip install pisces[e1]`.
-
 ## 0.3.0
 
 * Python 3 support!

--- a/pisces/schema/css3.py
+++ b/pisces/schema/css3.py
@@ -455,7 +455,7 @@ szz = Column(Float(24),
              info={'default': -100000000, 'parse': parse_float, 'dtype': 'float', 'width': 15, 'format': '15.4f'})
 
 tagid = Column(Integer,
-               info={'default': -1, 'parse': parse_float, 'dtype': 'float', 'width': 8, 'format': '8d'})
+               info={'default': -1, 'parse': parse_int, 'dtype': 'int', 'width': 8, 'format': '8d'})
 
 tagname = Column(String(8),
                  info={'default': '-', 'parse': parse_str, 'dtype': 'a8', 'width': 8, 'format': '8.8s'})
@@ -931,7 +931,7 @@ class Wftag(Base):
 
     @declared_attr
     def __table_args__(cls):
-        return (PrimaryKeyConstraint('tagid'), UniqueConstraint('tagname', 'tagid', 'wfid'),)
+        return (PrimaryKeyConstraint('tagname', 'tagid', 'wfid'),)
 
     tagname = tagname.copy()
     tagid = tagid.copy()

--- a/pisces/schema/kbcore.py
+++ b/pisces/schema/kbcore.py
@@ -497,7 +497,7 @@ szz = Column(Float(24),
              info={'default': -100000000, 'parse': parse_float, 'dtype': 'float', 'width': 15, 'format': '15.4f'})
 
 tagid = Column(Integer,
-               info={'default': -1, 'parse': parse_float, 'dtype': 'float', 'width': 9, 'format': '9d'})
+               info={'default': -1, 'parse': parse_int, 'dtype': 'int', 'width': 9, 'format': '9d'})
 
 tagname = Column(String(8),
                  info={'default': '-', 'parse': parse_str, 'dtype': 'a8', 'width': 8, 'format': '8.8s'})
@@ -967,7 +967,7 @@ class Wftag(Base):
 
     @declared_attr
     def __table_args__(cls):
-        return (PrimaryKeyConstraint('tagid'), UniqueConstraint('tagname', 'tagid', 'wfid'),)
+        return (PrimaryKeyConstraint('tagname', 'tagid', 'wfid'),)
 
     tagname = tagname.copy()
     tagid = tagid.copy()


### PR DESCRIPTION
In both KB Core and CSS3 schema, the following fixes were made:

* `tagid` is parsed as an integer instead of float.
* `Wftag` table primary keys are `tagname`, `tagid`, and `wfid` instead of just `tagid`.

Fixes #25 
