### PR TITLE
Allow SQLAlchemy 1.4 in preparation for 2.0

### DIFF
--- a/pisces/schema/util.py
+++ b/pisces/schema/util.py
@@ -6,10 +6,9 @@ from collections import namedtuple
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
 try:
-    from sqlalchemy.ext.declarative.api import _declarative_constructor
+    from sqlalchemy.orm import as_declarative
 except ImportError:
-    # not >0.8
-    from sqlalchemy.ext.declarative import _declarative_constructor
+    from sqlalchemy.ext.declarative.api import _declarative_constructor
 
 # NO SELF IMPORTS!
 
@@ -178,7 +177,11 @@ def _init(self, *args, **kwargs):
     else:
         # keyword value instantiation
         # use SQLA's keyword constructor, then replace None attribute values with defaults
-        _declarative_constructor(self, **kwargs)
+        try:
+            as_declarative(self, **kwargs)
+        except NameError:
+            _declarative_constructor(self, **kwargs)
+
         for c, ival in [(col, getattr(self, self._attrname[col.name], None)) for col in self.__table__.columns]:
             dflt = c.info.get('default', None)
             if ival is None:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='pisces',
       url='https://github.com/LANL-Seismoacoustics/pisces',
       download_url='https://github.com/LANL-Seismoacoustics/pisces/tarball/0.3.2',
       keywords = ['seismology', 'geophysics', 'database'],
-      install_requires=['numpy','obspy>=1.0','sqlalchemy >1.0, <1.4','Click'],
+      install_requires=['numpy','obspy>=1.0','sqlalchemy >1.0, <=1.4','Click'],
       extras_require={
          'e1': ["e1"],
       },


### PR DESCRIPTION
SQLA 2.0 will have some breaking changes.  This branch follows [their guide](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html) and [changes in 1.4](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html) to prepare Pisces for SQLAlchemy 2.0.

* [ ] Make sure SQLA 1.3 works without deprecation warnings.
* [ ] Make SQLA 1.4 work.
* [ ] Python 3.6+ only.

On quick scan, I think [this](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#declarative-is-now-integrated-into-the-orm-with-new-features) section contains relevant changes.