### PR TITLE
Fix Windows compilation error - e_compression.c

### DIFF
--- a/pisces/io/src/e_compression/e_compression.c
+++ b/pisces/io/src/e_compression/e_compression.c
@@ -64,15 +64,36 @@
 #define EC_MAKECHECK(x) ((((x) & 0x00ffffff) << 8) >> 8)
 
 
-/* Python C extensions for Windows expects the symbol initModuleName when building the library.
-* This declaration gives msvc compiler this symbol to compile correctly.
-* Note : This not the documented way to build C extensions for Windows. It is typically expected to
-* use wrapper methods. What this does is prevents a statement such as 'import libecompression' in Python.
-* Instead, the only way to load the library is through a ctypes.CDLL call. Which in this case, is all that
-* is needed as seen in readwaveform.py.
+/* Initialize a bare-bones Python module. This module isn't meant to be used directly, but rather it is
+* interacted with through a ctypes.CDLL call. However, particularly on Windows, a module definition is
+* required to get this file to compile.
 */
 #ifdef _WIN32
-void initlibecompression(){}
+PyMODINIT_FUNC PyInit__libe1(void)
+{
+  /* define a basic PyObject with just a name and docstring */
+  PyObject *m;
+  static struct PyModuleDef mdef = {
+    PyModuleDef_HEAD_INIT,
+    "_libe1",                       /* name */
+     "Library for e1 compression",  /* docstring */
+     -1,                            /* size */
+     NULL,                          /* methods */
+     NULL,                          /* reload */
+     NULL,                          /* traverse */
+     NULL,                          /* clear */
+     NULL                           /* free */
+  };
+  
+  /* create the module described above */
+  m = PyModule_Create(&mdef);
+  
+  /* return */
+  if (!m)
+    return NULL;
+  else
+    return m;
+}
 #endif
 
 /*


### PR DESCRIPTION
From my Googling, since Python 3, CPython modules supposedly *require* a PyMODINIT statement. The lack of this statement resulted in a failure to compile this module on Windows with "error LNK2001: unresolved external symbol PyInit__libe1". Given that the module definition is required, I don’t know why Windows was failing to compile it while it worked on Mac/Linux. Regardless, this change appears to fix the compiling error on Windows.

In testing, a simple statement that returns NULL will suffice...
```c
PyMODINIT_FUNC PyInit__libe1(void){return NULL;}
```
...but that seems particularly hack-ey and prone to future breakage, so I opted to define a methodless PyObject, instead.