### PR TITLE
Implement "asquery" for get_waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## master/main
 
+
+## 0.4.1
+
+* Drop testing on Python 3.6, add 3.9 and 3.10
+* Drop AppVeyor for testing on Windows, use GitHub Actions instead
+* The unimplemented `stime` keyword in `pisces.request.get_stations` has been replaced
+  with `time_span`, which accepts time ranges as YYYYddd julian dates.
+* Fixed typo in `pisces.request.get_stations` implementation of `nets` keyword.
+* New handling of wildcards in `pisces.request.get_stations`
+* Fixed typo in `pisces.request.get_stations` implementation of `channels` keyword.
+* Fixed typo in `pisces.requests.wfdisc_rows_to_stream` 😳 Yikes!
+* New contributor Samuel Chodur!
+* Use GitHub Actions for wheels and releases to PyPI
+* Add `asquery` option to `pisces.request.get_waveforms`
+
 ## 0.4.0
 * Bump required SQLAlchemy version to add least 1.4
 * Updated import locations of `sqlalchemy.ext.declarative.api` functions to `sqlalchemy.orm`

--- a/pisces/request.py
+++ b/pisces/request.py
@@ -485,7 +485,7 @@ def get_arrivals(session, arrival, assoc=None, stations=None, channels=None,
 
 
 def get_waveforms(session, wfdisc, station=None, channel=None, starttime=None,
-                  endtime=None, wfids=None, tol=None):
+                  endtime=None, wfids=None, tol=None, asquery=False):
     """
     Request waveforms.
 
@@ -505,6 +505,9 @@ def get_waveforms(session, wfdisc, station=None, channel=None, starttime=None,
     tol : float
         If provided, a warning is fired if any Trace is not within tol seconds
         of starttime and endtime.
+    asquery : bool, optional
+        Return the query object instead of the results.  Default, False.
+        Useful if additional you desire additional sorting of filtering.
 
     Returns
     -------
@@ -527,9 +530,14 @@ def get_waveforms(session, wfdisc, station=None, channel=None, starttime=None,
     t2_utc = UTCDateTime(endtime) if endtime is not None else None
 
     wfs = get_wfdisc_rows(session, Wfdisc, station, channel, starttime, endtime,
-                          wfids=wfids)
+                          wfids=wfids, asquery=asquery)
 
-    return wfdisc_rows_to_stream(wfs, t1_utc, t2_utc, tol=tol)
+    if asquery:
+        res = wfs
+    else:
+        res = wfdisc_rows_to_stream(wfs, t1_utc, t2_utc, tol=tol)
+
+    return res
     
 
 def wfdisc_rows_to_stream(wf_rows, start_t, end_t, tol=None):


### PR DESCRIPTION
As many functions in the `request` module offer returning the SQLAlchemy `Query` object, for extra filtering and manipulation, this PR does so for the `get_waveforms` function.  In this mode, a query is return instead of an ObsPy `Stream`.

EDIT: I also updated the CHANGELOG for recent changes since `v0.4.0`.  I know I shouldn't do that here, but my git-fu just wasn't good enough to keep them separate.