### PR TITLE
Query events

### DIFF
--- a/pisces/events.py
+++ b/pisces/events.py
@@ -257,8 +257,8 @@ def filter_events(
     range_restr = []
     if time_:
         t1, t2 = time_
-        t1 = t1 if t1 else None
-        t2 = t2 if t2 else None
+        t1 = UTCDateTime(t1).timestamp if t1 else None
+        t2 = UTCDateTime(t2).timestamp if t2 else None
         time_ = (t1, t2)
         range_restr.append((Origin.time, *time_))
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,6 +11,8 @@ from obspy import UTCDateTime
 from pisces.tables.kbcore import *
 from pisces import events
 
+# for scope='module' these database rows are added to a temp database once for this whole file,
+# then removed at the end. Not sure that's necessary.
 @pytest.fixture(scope='module')
 def eventdata(session):
     lat = 40

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -238,6 +238,13 @@ def test_magnitude_origin_netmag_stamag(session, eventdata):
         r[0] == (d['origin1'], d['netmag1'], d['stamag3'])
     )
 
+    # sta
+    r = events.filter_magnitudes(q, sta='*2').order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin2'], d['netmag2'], d['stamag2'])
+    )
+
     # pop in Netmag
     q = session.query(Origin, Stamag)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -17,13 +17,23 @@ def eventdata(session):
     lon = 25
     depth = 15
     time_ = UTCDateTime('2000-01-01').timestamp
+    # event stuff
     data = {
         'event1': Event(evid=1, prefor=1, evname='an important description'),
-        'origin1': Origin(orid=1, evid=1, lat=lat, lon=lon, depth=depth, time=time_, auth='auth1'),
-        'origin2': Origin(orid=2, evid=1, lat=lat+1, lon=lon+1, depth=depth+1, time=time_+1),
+        'origin1': Origin(orid=1, evid=1, lat=lat, lon=lon, depth=depth, time=time_, auth='auth1', mb=4.1, mbid=1, ms=5, ml=6, mlid=2),
+        'origin2': Origin(orid=2, evid=1, lat=lat+1, lon=lon+1, depth=depth+1, time=time_+1, ml=5),
         'event2': Event(evid=2, prefor=3, evname='another description'),
-        'origin3': Origin(orid=3, evid=2, lat=lat-5, lon=lon-5, depth=depth-5, time=time_-5, etype='ex', auth='auth2'),
+        'origin3': Origin(orid=3, evid=2, lat=lat-5, lon=lon-5, depth=depth-5, time=time_-5, etype='ex', auth='auth2', mb=2, ms=3, ml=4),
     }
+    # magnitude stuff
+    data.update({
+        'netmag1': Netmag(net='IM', orid=1, evid=1, magtype='mb', magnitude=4, magid=1, auth='ISC'),
+        'netmag2': Netmag(net='IN', orid=2, evid=1, magtype='ml', magnitude=6, magid=2, auth='ISD'),
+        'stamag1': Stamag(sta='sta1', arid=1, magtype='ml', magnitude=4.1, magid=2, orid=1, auth='ISD'),
+        'stamag2': Stamag(sta='sta2', arid=2, magtype='ml', magnitude=3.9, magid=2, orid=2, auth='ISD'),
+        'stamag3': Stamag(sta='sta1', arid=3, magtype='mb', magnitude=3.9, magid=1, orid=1, auth='ISE'),
+    })
+
     session.add_all(list(data.values()))
     session.commit()
 
@@ -99,8 +109,8 @@ def test_events_event(session, eventdata):
 
     q = session.query(Event)
 
-    # evname
-    r = events.filter_events(q, name='important').order_by(Event.evid).all()
+    # evname, with two different kinds of wildcard
+    r = events.filter_events(q, evname='*important%').order_by(Event.evid).all()
     assert (
         len(r) == 1 and
         r[0] == d['event1']
@@ -139,6 +149,7 @@ def test_events_origin_event(session, eventdata):
 
 def test_events_exceptions(session):
     """ Test expected exceptions. """
+
     # Origin input with no Origin table
     q = session.query(Event)
     with pytest.raises(ValueError):
@@ -149,11 +160,100 @@ def test_events_exceptions(session):
     with pytest.raises(ValueError):
         r = events.filter_events(q, evid=[1])
 
-    # both evid and orid specified
-    q = session.query(Event, Origin)
-    with pytest.raises(ValueError):
-        r = events.filter_events(q, evid=[1], orid=[2j])
+
+def test_magnitudes_origin(session, eventdata):
+    d, *_ = eventdata
+
+    q = session.query(Origin)
+
+    # origin magnitudes
+    r = events.filter_magnitudes(q, ml=(4.5, 5.5), mb=(3, None)).order_by(Origin.orid).all()
+    assert (
+        len(r) == 2 and
+        r[0] == d['origin1'] and
+        r[1] == d['origin2']
+    )
+
+    # TODO: filter_magnitudes(q, **{'m?': (1, 2)}) should fail with only Origin
+
+    # auth
+    r = events.filter_magnitudes(q, auth='auth?').order_by(Origin.orid).all()
+    assert (
+        len(r) == 2 and
+        r[0] == d['origin1'] and
+        r[1] == d['origin3']
+    )
+
+def test_magnitude_origin_netmag(session, eventdata):
+    d, *_ = eventdata
+
+    q = session.query(Origin, Netmag)
+
+    # non-origin magnitudes, joined results
+    r = events.filter_magnitudes(q, **{'m?': (5, None)}).order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin2'], d['netmag2'])
+    )
+
+    # net
+    r = events.filter_magnitudes(q, net='?M').order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin1'], d['netmag1'])
+    )
+
+    # auth
+    r = events.filter_magnitudes(q, auth='*D').order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin2'], d['netmag2'])
+    )
+
+    # pop in Netmag to get only Origin results filtered on Netmag
+    q = session.query(Origin)
+    r = events.filter_magnitudes(q, ml=(5, None), netmag=Netmag).order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == d['origin2']
+    )
 
 
-# def test_magnitudes(session, data):
-    # pass
+def test_magnitude_origin_netmag_stamag(session, eventdata):
+    d, *_ = eventdata
+
+    q = session.query(Origin, Netmag, Stamag)
+
+    # mb from Stamag, joined with the correct Origin, Netmag rows
+    r = events.filter_magnitudes(q, mb=(None, 4)).order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin1'], d['netmag1'], d['stamag3'])
+    )
+
+    # auth from Stamag
+    r = events.filter_magnitudes(q, auth='*E').order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin1'], d['netmag1'], d['stamag3'])
+    )
+
+    # pop in Netmag
+    q = session.query(Origin, Stamag)
+
+    # mb from Stamag, joined with the correct Origin rows
+    r = events.filter_magnitudes(q, mb=(None, 4), netmag=Netmag).order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == (d['origin1'], d['stamag3'])
+    )
+
+    # pop in Stamag
+    # get Origin rows filtered on Stamag magnitudes
+    q = session.query(Origin)
+
+    r = events.filter_magnitudes(q, mb=(None, 4), stamag=Stamag).order_by(Origin.orid).all()
+    assert (
+        len(r) == 1 and
+        r[0] == d['origin1']
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,7 +78,7 @@ def test_load_config_dict():
     assert tables == {}
 
 def test_range_filters():
-    # empty values
+    # empty values produces no filters, just an empty list
     assert events.range_filters((Site.lat, None, None)) == []
 
     # min value


### PR DESCRIPTION
Rewrite/reorg of event functionality from `request.get_events` into a new query-centric `events.py` submodule.

How this is different from functions in `request.py`:
- All functions accept a SQLAlchemy query object that generally already include the tables in their result set, instead of users supplying `Sesssion` and all ORM table objects required for the function.  This makes the calling signatures cleaner, and makes the result set more predictable for users, since they are now responsible for things like `query = session.query(Event, Origin)`.
- Users are responsible for knowing how to initialize a query (see above).
- Functions accept and return query objects.  Users are how responsible for realizing the result set (e.g. `query.all()`, or `query.limit(100).all()`).
- Natural joins of target tables are performed inside each function (e.g. `Event.evid == Origin.evid`, `Stamag.magid == Netmag.magid`)
- Each function also accepts required tables as keywords if they weren't already in the result set , so that tables can be filtered and joined in the query but not included in the results. (e.g. `session.query(Origin)` doesn't have `Event`, but `Event.prefor` could be used to filter origins)
- Event querying is broken out into 3 functions:
  - `filter_events` : geographic (lat, lon, depth, etc.) and catagorical (evid, orid, auth, etype) filtering (`WHERE` clauses in SQL) filtering of a query, targeting Event and Origin tables.
  - `filter_magnitudes`: magnitude filtering, targeting Origin, Netmag, and Stamag tables.
  - `filter_arrivals`: phase arrival filtering, targeting Arrival and Assoc tables.
- Some function parameters like `auth` may be found in more than one provided table.  In this case, the function documents how it handles the ambiguity.  If this assumption is not desired, the user should avoid the parameter and add the desired filter to the manually.

ping @cnlg-lanl 